### PR TITLE
Avoid N+1 queries when using ActiveStorage

### DIFF
--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -2,7 +2,7 @@ class SpeakersController < APIController
   before_action :set_speaker, only: %i[show update destroy]
 
   def index
-    @speakers = Speaker.all
+    @speakers = Speaker.with_attached_avatar
     json_response(@speakers)
   end
 

--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -2,7 +2,7 @@ class SponsorsController < APIController
   before_action :set_sponsor, only: %i[show update destroy]
 
   def index
-    @sponsors = Sponsor.all
+    @sponsors = Sponsor.with_attached_logo
     json_response(@sponsors)
   end
 

--- a/db/migrate/20180929162623_create_speakers.rb
+++ b/db/migrate/20180929162623_create_speakers.rb
@@ -1,6 +1,6 @@
 class CreateSpeakers < ActiveRecord::Migration[5.2]
   def change
-    create_table :sponsors do |t|
+    create_table :speakers do |t|
       t.string :name
       t.string :email
       t.string :company


### PR DESCRIPTION
This [article](https://evilmartians.com/chronicles/rails-5-2-active-storage-and-beyond) explains the base of ActiveStorage and exposes the N+1 problem that the basic usage creates. 

If you want to avoid other N+1 queries you should take a look on [this gem](https://github.com/flyerhzm/bullet)